### PR TITLE
OLMIS-7660: Revert Add sticky position to header in mobile app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-5.2.3-WIP
-==================
-Improvements:
-* [OLMIS-7660](https://openlmis.atlassian.net/browse/OLMIS-7660): Add sticky position to header in mobile app.
-
-
 5.2.2 / 2022-10-07
 ==================
 

--- a/src/openlmis-header/_header.scss
+++ b/src/openlmis-header/_header.scss
@@ -4,11 +4,6 @@ body > header {
     border: 0px;
     padding: 0px;
 
-    @media screen and (max-width: $res-md) {
-        position: sticky;
-        top: 0;
-    }
-
     > * {
         width: 100%;
         margin: 0px;


### PR DESCRIPTION
Deleted this line of code as I added it in another repository: ui-components