### PR TITLE
MW-1449 - Fix CSP script-src for external domains

### DIFF
--- a/src/openlmis-home/csp-generate.run.js
+++ b/src/openlmis-home/csp-generate.run.js
@@ -66,7 +66,8 @@
             var cspHeader =
                 'default-src \'self\' ' + joinedDomains + ' \'unsafe-inline\';\n' +
                 'img-src \'self\' ' + GOOGLE_ANALYTICS_URL + ';\n' +
-                'script-src \'self\' ' + GOOGLE_ANALYTICS_URL + ' \'unsafe-inline\' \'unsafe-eval\';\n' +
+                'script-src \'self\' ' + GOOGLE_ANALYTICS_URL + ' ' +
+                joinedDomains + ' \'unsafe-inline\' \'unsafe-eval\';\n' +
                 'connect-src \'self\' ' + GOOGLE_ANALYTICS_URL + ' ' + joinedDomains + ';\n' +
                 'frame-src \'self\' ' + joinedDomains + ';';
 


### PR DESCRIPTION
The CSP generator adds external domains (including SUPERSET_URL) to connect-src and frame-src but omits them from script-src, blocking scripts served from those domains. Required for the new Superset Embedded SDK integration. WIP until the reporting stack integration is tested and merged.

## Summary
- Add `joinedDomains` to `script-src` in CSP generator, matching `connect-src` and `frame-src`