### PR TITLE
OLMIS-8220: fix language picker hidden on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Upcoming Version (WIP)
 ==================
 
+
+Bug fixes:
+* [OLMIS-8220](https://openlmis.atlassian.net/browse/OLMIS-8220): Fix language picker dropdown on mobile device
+
+
 5.2.10 / 2026-02-05
 =================
 Improvements:

--- a/src/openlmis-header/_header.scss
+++ b/src/openlmis-header/_header.scss
@@ -3,6 +3,8 @@ $font-size-openlmis-header-title: $font-size-extra-large !default;
 body > header {
   border: 0px;
   padding: 0px;
+  position: relative;
+  z-index: 10;
   > * {
     width: 100%;
     margin: 0px;


### PR DESCRIPTION
On mobile the language dropdown was painted behind the page content. Promoted the body header, so dropdowns are on top