### PR TITLE
OLMIS-8220: Raise header z-index above sticky content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Upcoming Version (WIP)
 
 Bug fixes:
 * [OLMIS-8220](https://openlmis.atlassian.net/browse/OLMIS-8220): Fix language picker dropdown on mobile device
+* [OLMIS-8220](https://openlmis.atlassian.net/browse/OLMIS-8220): Raise header z-index above sticky content
 
 
 5.2.10 / 2026-02-05

--- a/src/openlmis-header/_header.scss
+++ b/src/openlmis-header/_header.scss
@@ -4,7 +4,7 @@ body > header {
   border: 0px;
   padding: 0px;
   position: relative;
-  z-index: 10;
+  z-index: $z-index-header-sticky;
   > * {
     width: 100%;
     margin: 0px;


### PR DESCRIPTION
Header now uses the shared layer variable so language dropdown stays on top.